### PR TITLE
Implement token management and Rest helper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,19 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-redis</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/com/github/sharifrahim/jwt_client/JwtClientApplication.java
+++ b/src/main/java/com/github/sharifrahim/jwt_client/JwtClientApplication.java
@@ -2,12 +2,19 @@ package com.github.sharifrahim.jwt_client;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class JwtClientApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(JwtClientApplication.class, args);
-	}
+        public static void main(String[] args) {
+                SpringApplication.run(JwtClientApplication.class, args);
+        }
+
+        @Bean
+        public RestTemplate restTemplate() {
+                return new RestTemplate();
+        }
 
 }

--- a/src/main/java/com/github/sharifrahim/jwt_client/auth/ProviderXTokenManager.java
+++ b/src/main/java/com/github/sharifrahim/jwt_client/auth/ProviderXTokenManager.java
@@ -1,0 +1,84 @@
+package com.github.sharifrahim.jwt_client.auth;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class ProviderXTokenManager implements TokenManager {
+
+    private final StringRedisTemplate redisTemplate;
+    private final RestTemplate restTemplate;
+    private final String clientId;
+    private final String clientSecret;
+    private final String tokenUrl;
+
+    public ProviderXTokenManager(StringRedisTemplate redisTemplate,
+                                 RestTemplate restTemplate,
+                                 @Value("${providerX.client-id}") String clientId,
+                                 @Value("${providerX.client-secret}") String clientSecret,
+                                 @Value("${providerX.token-url}") String tokenUrl) {
+        this.redisTemplate = redisTemplate;
+        this.restTemplate = restTemplate;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.tokenUrl = tokenUrl;
+    }
+
+    @Override
+    public String getToken() {
+        String accessTokenKey = "providerX:access_token";
+        String refreshTokenKey = "providerX:refresh_token";
+        String token = redisTemplate.opsForValue().get(accessTokenKey);
+        if (token != null) {
+            return token;
+        }
+        String refreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
+        if (refreshToken != null) {
+            return refreshToken(refreshToken, accessTokenKey, refreshTokenKey);
+        }
+        return fetchNewTokens(accessTokenKey, refreshTokenKey);
+    }
+
+    private String fetchNewTokens(String accessTokenKey, String refreshTokenKey) {
+        Map<String, String> request = Map.of(
+                "client_id", clientId,
+                "client_secret", clientSecret,
+                "grant_type", "client_credentials");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response = restTemplate.postForObject(tokenUrl, request, Map.class);
+        return storeTokensFromResponse(response, accessTokenKey, refreshTokenKey);
+    }
+
+    private String refreshToken(String refreshToken, String accessTokenKey, String refreshTokenKey) {
+        Map<String, String> request = Map.of(
+                "refresh_token", refreshToken,
+                "grant_type", "refresh_token",
+                "client_id", clientId,
+                "client_secret", clientSecret);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response = restTemplate.postForObject(tokenUrl, request, Map.class);
+        return storeTokensFromResponse(response, accessTokenKey, refreshTokenKey);
+    }
+
+    private String storeTokensFromResponse(Map<String, Object> response, String accessTokenKey, String refreshTokenKey) {
+        if (response == null) {
+            throw new IllegalStateException("No token response from provider");
+        }
+        String accessToken = (String) response.get("access_token");
+        Integer expiresIn = (Integer) response.getOrDefault("expires_in", 3600);
+        String refreshToken = (String) response.get("refresh_token");
+        Integer refreshExpires = (Integer) response.getOrDefault("refresh_expires_in", 86400);
+        if (accessToken != null) {
+            redisTemplate.opsForValue().set(accessTokenKey, accessToken, Duration.ofSeconds(expiresIn));
+        }
+        if (refreshToken != null) {
+            redisTemplate.opsForValue().set(refreshTokenKey, refreshToken, Duration.ofSeconds(refreshExpires));
+        }
+        return accessToken;
+    }
+}

--- a/src/main/java/com/github/sharifrahim/jwt_client/auth/TokenFactory.java
+++ b/src/main/java/com/github/sharifrahim/jwt_client/auth/TokenFactory.java
@@ -1,0 +1,21 @@
+package com.github.sharifrahim.jwt_client.auth;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenFactory {
+
+    private final Map<String, TokenManager> managers;
+
+    public TokenFactory(ProviderXTokenManager providerXTokenManager) {
+        this.managers = Map.of("providerX", providerXTokenManager);
+    }
+
+    public TokenManager get(String provider) {
+        return Optional.ofNullable(managers.get(provider))
+                .orElseThrow(() -> new IllegalArgumentException("Unknown provider: " + provider));
+    }
+}

--- a/src/main/java/com/github/sharifrahim/jwt_client/auth/TokenManager.java
+++ b/src/main/java/com/github/sharifrahim/jwt_client/auth/TokenManager.java
@@ -1,0 +1,5 @@
+package com.github.sharifrahim.jwt_client.auth;
+
+public interface TokenManager {
+    String getToken();
+}

--- a/src/main/java/com/github/sharifrahim/jwt_client/controller/DemoController.java
+++ b/src/main/java/com/github/sharifrahim/jwt_client/controller/DemoController.java
@@ -1,0 +1,25 @@
+package com.github.sharifrahim.jwt_client.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.sharifrahim.jwt_client.helper.RestHelper;
+
+@RestController
+@RequestMapping("/demo")
+public class DemoController {
+
+    private final RestHelper restHelper;
+
+    public DemoController(RestHelper restHelper) {
+        this.restHelper = restHelper;
+    }
+
+    @GetMapping("/call")
+    public ResponseEntity<String> call(@RequestParam String provider, @RequestParam String url) {
+        return restHelper.get(provider, url);
+    }
+}

--- a/src/main/java/com/github/sharifrahim/jwt_client/helper/RestHelper.java
+++ b/src/main/java/com/github/sharifrahim/jwt_client/helper/RestHelper.java
@@ -1,0 +1,30 @@
+package com.github.sharifrahim.jwt_client.helper;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.github.sharifrahim.jwt_client.auth.TokenFactory;
+
+@Component
+public class RestHelper {
+
+    private final RestTemplate restTemplate;
+    private final TokenFactory tokenFactory;
+
+    public RestHelper(RestTemplate restTemplate, TokenFactory tokenFactory) {
+        this.restTemplate = restTemplate;
+        this.tokenFactory = tokenFactory;
+    }
+
+    public ResponseEntity<String> get(String provider, String url) {
+        String token = tokenFactory.get(provider).getToken();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        return restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=jwt_client
+spring.redis.host=localhost
+spring.redis.port=6379
+
+# Provider X credentials
+providerX.client-id=dummy
+providerX.client-secret=dummy-secret
+providerX.token-url=http://localhost/token


### PR DESCRIPTION
## Summary
- add Spring Web and Redis dependencies
- configure Redis and provider credentials
- add token management classes (TokenManager, ProviderXTokenManager, TokenFactory)
- implement RestHelper and a demo controller
- expose RestTemplate bean

## Testing
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_685b0ef3ce388323af2f741bc5ba1c83